### PR TITLE
chore(ts): align monorepo for TS7 (composite refs + deprecation guard)

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "./dist",
     "noEmit": false,
     "jsx": "react-jsx",
-    "composite": true
+    "composite": true,
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*", "index.html"],
   "exclude": [

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "noEmit": false,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "composite": true
   },
   "include": ["src/**/*", "index.html"],
   "exclude": [

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "noEmit": false
+    "noEmit": false,
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.*", "**/*.spec.*"]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "noEmit": false
+    "noEmit": false,
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.*", "**/*.spec.*", "**/*.old"]

--- a/packages/gaming/tsconfig.json
+++ b/packages/gaming/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "noEmit": false
+    "noEmit": false,
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.*", "**/*.spec.*"]

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true
   },
   "include": ["src/**/*", "../../levels.config.d.ts", "config/**/*.d.ts"],
   "exclude": ["dist", "node_modules"]

--- a/packages/search/tsconfig.json
+++ b/packages/search/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "noEmit": false
+    "noEmit": false,
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.*", "**/*.spec.*"]

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "noEmit": false
+    "noEmit": false,
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": [

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "noEmit": false
+    "noEmit": false,
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.*", "**/*.spec.*"]

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "noEmit": false,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.*", "**/*.spec.*", "**/*.stories.*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,7 +52,10 @@
       "@heys/analytics": ["./packages/analytics/src"],
       "@heys/shared": ["./packages/shared/src"],
       "@heys/logger": ["./packages/logger/src"]
-    }
+    },
+
+    // TS7 deprecation guard for baseUrl
+    "ignoreDeprecations": "6.0"
   },
 
   // Workspace references


### PR DESCRIPTION
## Цель\nТехдолг: подготовить конфиги TypeScript к обновлению до 7.x, убрать предупреждения и включить сборку проектных ссылок.\n\n## Сделано\n- Добавлен  в корневой  и в  для подавления предупреждения по  до миграции (TS7).\n- Включён  во всех пакетах, которые участвуют в project references: core, ui, search, storage, gaming, analytics, shared, logger, а также в приложении .\n- Это необходимо, чтобы устранить ошибки вида: .\n\n## Почему это безопасно\n лишь включает генерацию доп. метаданных для инкрементальной сборки — поведение рантайма не меняется. Поля  остаются как было; в корне всё ещё  для общего режима разработки.\n\n## Не сделано (осознанно)\n- Не удалён : для текущей структуры путей важно сохранить его до окончательной миграции на чистые path aliases через импорт из сборки.\n- Не добавлены build scripts для по-пакетной компиляции — это отдельная оптимизация.\n\n## Следующие шаги (при желании)\n1. Добавить общий скрипт:  ERR_PNPM_NO_SCRIPT  Missing script: type-build

Command "type-build" not found. Did you mean "pnpm run build"? (tsc -b .) для проверки консистентности ссылок.\n2. Постепенно убрать  и перейти на относительные + экспортные алиасы через  в package.json.\n3. Включить  в пакетах с тяжёлой компиляцией (пока рано).\n4. Добавить CI шаг  для быстрого контроля ссылок.\n\n## Проверка\n- Локальный commit проходит тесты и dev build.\n- Предупреждение о deprecated  подавлено.\n\nГотово к ревью.